### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/assets/stylesheets/items/index.scss
+++ b/app/assets/stylesheets/items/index.scss
@@ -242,6 +242,7 @@ a {
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
+  
 }
 
 .item-lists>.list {

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,6 +3,8 @@ class ItemsController < ApplicationController
 
   def index
     @items = Item.order('created_at DESC')
+    @items = Item.all
+
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -4,7 +4,6 @@ class ItemsController < ApplicationController
   def index
     @items = Item.order('created_at DESC')
     @items = Item.all
-
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,7 +3,6 @@ class ItemsController < ApplicationController
 
   def index
     @items = Item.order('created_at DESC')
-    @items = Item.all
   end
 
   def new

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -123,42 +123,36 @@
   <%# 商品一覧 %>
   <div class='item-contents'>
     <h2 class='title'>ピックアップカテゴリー</h2>
-    <%= link_to '新規投稿商品', "#", class: "subtitle" %>
+    <%= link_to '新規投稿商品', new_item_path, class: "subtitle" %>
     <ul class='item-lists'>
-
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+     <% @items.each do |item|%>
       <li class='list'>
-        <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag(item.image, class: "item-img") %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div>
+          <%# <div class='sold-out'> %>
+            <%# <span>Sold Out!!</span> %>
+          <%# </div> %>
           <%# //商品が売れていればsold outを表示しましょう %>
 
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.item_name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br><%= item.cost.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
             </div>
           </div>
         </div>
+        </li>
         <% end %>
-      </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
       <li class='list'>
-        <%= link_to '#' do %>
+        <% if @items.length == 0 %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
         <div class='item-info'>
           <h3 class='item-name'>
@@ -174,8 +168,6 @@
         </div>
         <% end %>
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_11_183149) do
+ActiveRecord::Schema.define(version: 2021_03_08_185900) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -28,31 +28,31 @@ RSpec.describe Item, type: :model do
       it 'category_idが空（---）のとき' do
         @item.category_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Category must be other than 1")
+        expect(@item.errors.full_messages).to include('Category must be other than 1')
       end
 
       it 'condition_idが空（---）のとき' do
         @item.condition_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Condition must be other than 1")
+        expect(@item.errors.full_messages).to include('Condition must be other than 1')
       end
 
       it 'cost_idが空（---）のとき' do
         @item.cost_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Cost must be other than 1")
+        expect(@item.errors.full_messages).to include('Cost must be other than 1')
       end
 
       it 'area_idが空（---）のとき' do
         @item.area_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Area must be other than 1")
+        expect(@item.errors.full_messages).to include('Area must be other than 1')
       end
 
       it 'datee_idが空（---）のとき' do
         @item.datee_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Datee must be other than 1")
+        expect(@item.errors.full_messages).to include('Datee must be other than 1')
       end
 
       it 'priceが空' do
@@ -92,7 +92,7 @@ RSpec.describe Item, type: :model do
       end
 
       it '出品金額が9,999,999円超過' do
-        @item.price = 10000000
+        @item.price = 10_000_000
         @item.valid?
         expect(@item.errors.full_messages).to include('Price must be less than 10000000')
       end


### PR DESCRIPTION
# What
商品の一覧をトップページに表示させる

# Why
出品した商品を表示させる必要があるため

# URL
商品データがない場合（rails db:migrate:reset実行）
https://gyazo.com/ae23e86d20aad51a0f78bbe06efc5dc1
商品がある場合
https://gyazo.com/baa88b8ec308a9d1adeb9b51b036ee0c

※soldout表示は商品購入機能実装時とのことで、コメントアウトしております。